### PR TITLE
Updated sg egress ports to also include 8451

### DIFF
--- a/aws-poc-deploy/main.tf
+++ b/aws-poc-deploy/main.tf
@@ -6,7 +6,7 @@ resource "random_string" "naming" {
 
 locals {
   prefix              = var.prefix
-  sg_egress_ports     = concat([443, 3306, 6666], range(8443, 8451))
+  sg_egress_ports     = concat([443, 3306, 6666], range(8443, 8452))
   sg_ingress_protocol = ["tcp", "udp"]
   sg_egress_protocol  = ["tcp", "udp"]
   workspace_confs     = var.workspaces


### PR DESCRIPTION
Since the range function generates a list of integers starting from the first argument up to (but not including) the second argument. 

So, range(8443, 8452) generates a list of integers from 8443 to 8451. The range is inclusive of the starting value and exclusive of the ending value.